### PR TITLE
Add basic Node.js scheduling app

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,11 @@
+# MyAutoMails
+
+Simple web app for scheduling OpenAI-powered scripts and emailing the results.
+
+## Setup
+1. Install dependencies with `npm install` (requires internet access).
+2. Create a MySQL database and run `schema.sql`.
+3. Configure environment variables for database, SMTP and OpenAI API keys.
+4. Start the server with `npm start`.
+
+The scheduler checks every minute for scripts whose `next_execution` is due and sends the generated response to the configured email addresses.

--- a/index.html
+++ b/index.html
@@ -1,1 +1,0 @@
-testttsa 

--- a/package.json
+++ b/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "myautomails",
+  "version": "1.0.0",
+  "description": "User script scheduling web app",
+  "main": "src/app.js",
+  "scripts": {
+    "start": "node src/app.js",
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs",
+  "dependencies": {
+    "express": "^4.18.2",
+    "mysql2": "^3.8.0",
+    "node-cron": "^3.0.3",
+    "nodemailer": "^6.9.8",
+    "openai": "^4.30.0"
+  }
+}

--- a/public/index.html
+++ b/public/index.html
@@ -1,0 +1,37 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="UTF-8">
+  <title>MyAutoMails</title>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css">
+</head>
+<body class="container py-5">
+  <h1 class="mb-4">Login</h1>
+  <form id="loginForm">
+    <div class="mb-3">
+      <label for="email" class="form-label">Email</label>
+      <input type="email" class="form-control" id="email" required>
+    </div>
+    <div class="mb-3">
+      <label for="password" class="form-label">Password</label>
+      <input type="password" class="form-control" id="password" required>
+    </div>
+    <button type="submit" class="btn btn-primary">Login</button>
+  </form>
+  <script>
+    document.getElementById('loginForm').addEventListener('submit', async (e) => {
+      e.preventDefault();
+      const res = await fetch('/api/auth/login', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          email: document.getElementById('email').value,
+          password: document.getElementById('password').value,
+        })
+      });
+      const data = await res.json();
+      alert(data.message || data.error);
+    });
+  </script>
+</body>
+</html>

--- a/schema.sql
+++ b/schema.sql
@@ -1,0 +1,17 @@
+CREATE TABLE users (
+  id INT AUTO_INCREMENT PRIMARY KEY,
+  name VARCHAR(100) NOT NULL,
+  email VARCHAR(255) NOT NULL UNIQUE,
+  password VARCHAR(255) NOT NULL,
+  plan VARCHAR(50) DEFAULT 'free'
+);
+
+CREATE TABLE scripts (
+  id INT AUTO_INCREMENT PRIMARY KEY,
+  user_id INT NOT NULL,
+  script TEXT NOT NULL,
+  period INT NOT NULL,
+  next_execution DATETIME NOT NULL,
+  emails VARCHAR(255) NOT NULL,
+  FOREIGN KEY (user_id) REFERENCES users(id)
+);

--- a/src/app.js
+++ b/src/app.js
@@ -1,0 +1,20 @@
+const express = require('express');
+const bodyParser = require('body-parser');
+const authRoutes = require('./routes/auth');
+const scriptRoutes = require('./routes/scripts');
+const scheduler = require('./scheduler');
+
+const app = express();
+app.use(bodyParser.json());
+app.use(express.static('public'));
+
+app.use('/api/auth', authRoutes);
+app.use('/api/scripts', scriptRoutes);
+
+const PORT = process.env.PORT || 3000;
+app.listen(PORT, () => {
+  console.log(`Server running on port ${PORT}`);
+});
+
+// start scheduler
+scheduler.start();

--- a/src/db.js
+++ b/src/db.js
@@ -1,0 +1,10 @@
+const mysql = require('mysql2/promise');
+
+const pool = mysql.createPool({
+  host: process.env.DB_HOST || 'localhost',
+  user: process.env.DB_USER || 'root',
+  password: process.env.DB_PASSWORD || '',
+  database: process.env.DB_NAME || 'automails',
+});
+
+module.exports = pool;

--- a/src/routes/auth.js
+++ b/src/routes/auth.js
@@ -1,0 +1,33 @@
+const express = require('express');
+const pool = require('../db');
+const router = express.Router();
+const bcrypt = require('bcryptjs');
+
+router.post('/register', async (req, res) => {
+  const { name, email, password, plan } = req.body;
+  try {
+    const hash = await bcrypt.hash(password, 10);
+    await pool.query('INSERT INTO users(name, email, password, plan) VALUES (?, ?, ?, ?)', [name, email, hash, plan]);
+    res.status(201).json({ message: 'User registered' });
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ error: 'DB error' });
+  }
+});
+
+router.post('/login', async (req, res) => {
+  const { email, password } = req.body;
+  try {
+    const [rows] = await pool.query('SELECT * FROM users WHERE email = ?', [email]);
+    if (!rows.length) return res.status(401).json({ error: 'Invalid credentials' });
+    const user = rows[0];
+    const match = await bcrypt.compare(password, user.password);
+    if (!match) return res.status(401).json({ error: 'Invalid credentials' });
+    res.json({ message: 'Login successful', user: { id: user.id, name: user.name, plan: user.plan } });
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ error: 'DB error' });
+  }
+});
+
+module.exports = router;

--- a/src/routes/scripts.js
+++ b/src/routes/scripts.js
@@ -1,0 +1,29 @@
+const express = require('express');
+const pool = require('../db');
+const router = express.Router();
+
+router.get('/', async (req, res) => {
+  try {
+    const [rows] = await pool.query('SELECT * FROM scripts');
+    res.json(rows);
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ error: 'DB error' });
+  }
+});
+
+router.post('/', async (req, res) => {
+  const { user_id, script, period, next_execution, emails } = req.body;
+  try {
+    await pool.query(
+      'INSERT INTO scripts(user_id, script, period, next_execution, emails) VALUES (?, ?, ?, ?, ?)',
+      [user_id, script, period, next_execution, emails]
+    );
+    res.status(201).json({ message: 'Script created' });
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ error: 'DB error' });
+  }
+});
+
+module.exports = router;

--- a/src/scheduler.js
+++ b/src/scheduler.js
@@ -1,0 +1,44 @@
+const cron = require('node-cron');
+const pool = require('./db');
+const { Configuration, OpenAIApi } = require('openai');
+const nodemailer = require('nodemailer');
+
+const openai = new OpenAIApi(new Configuration({
+  apiKey: process.env.OPENAI_KEY || 'YOUR_API_KEY',
+}));
+
+const transporter = nodemailer.createTransport({
+  host: process.env.SMTP_HOST || 'smtp.example.com',
+  port: process.env.SMTP_PORT || 587,
+  secure: false,
+  auth: {
+    user: process.env.SMTP_USER || 'user',
+    pass: process.env.SMTP_PASS || 'pass',
+  },
+});
+
+async function checkScripts() {
+  try {
+    const [rows] = await pool.query('SELECT * FROM scripts WHERE next_execution <= NOW()');
+    for (const script of rows) {
+      const response = await openai.createChatCompletion({
+        model: 'gpt-3.5-turbo',
+        messages: [{ role: 'user', content: script.script }],
+      });
+      const answer = response.data.choices[0].message.content;
+      await transporter.sendMail({
+        from: process.env.SMTP_FROM || 'noreply@example.com',
+        to: script.emails,
+        subject: 'Script result',
+        text: answer,
+      });
+      await pool.query('UPDATE scripts SET next_execution = DATE_ADD(next_execution, INTERVAL period HOUR) WHERE id = ?', [script.id]);
+    }
+  } catch (err) {
+    console.error('Scheduler error', err);
+  }
+}
+
+module.exports.start = () => {
+  cron.schedule('* * * * *', checkScripts); // run every minute
+};


### PR DESCRIPTION
## Summary
- setup package.json with dependencies for express, mysql2, node-cron, nodemailer and openai
- implement Express server with routes for auth and script management
- add scheduler that calls OpenAI and sends result emails
- provide Bootstrap-based login page
- include sample MySQL schema and project README

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68726f921a708330a8b70196f7d5f2a7