### PR TITLE
Fix README scheduler section

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,5 +15,3 @@ being stored. Login is available at `/index.html`.
 The scheduler checks every minute for scripts whose `next_execution` is due and
 sends the generated response to the configured email addresses.
 
-The scheduler checks every minute for scripts whose `next_execution` is due and sends the generated response to the configured email addresses.
-


### PR DESCRIPTION
## Summary
- remove duplicated scheduler sentence in README

## Testing
- `npm install`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68727ff2417c8330980dd8cbd4d95c7f