### PR TITLE
Improve scheduler logic and user script management

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,4 +10,4 @@ Simple web app for scheduling OpenAI-powered scripts and emailing the results.
 
 Users can register via `/register.html`; passwords are hashed with bcrypt before being stored. Login is available at `/index.html`.
 
-The scheduler checks every minute for scripts whose `next_execution` is due and sends the generated response to the configured email addresses.
+The scheduler checks every five minutes. If a script's `next_execution` time falls within two minutes of the current time, it triggers a request to OpenAI and mails the response to the specified recipients.

--- a/package.json
+++ b/package.json
@@ -12,11 +12,12 @@
   "license": "ISC",
   "type": "commonjs",
   "dependencies": {
+    "bcryptjs": "^2.4.3",
     "express": "^4.18.2",
+    "express-session": "^1.18.1",
     "node-cron": "^3.0.3",
     "nodemailer": "^7.0.5",
     "openai": "^4.30.0",
-    "bcryptjs": "^2.4.3",
     "pg": "^8.11.3"
   }
 }

--- a/public/dashboard.html
+++ b/public/dashboard.html
@@ -7,7 +7,7 @@
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css">
   <link rel="stylesheet" href="style.css">
 </head>
-<body class="container py-5">
+<body class="container py-5 fade-in">
   <header>
     <img src="logo.png" alt="logo">
     <div>
@@ -20,9 +20,22 @@
   </header>
   <h1 data-i18n="welcome" class="mb-4">Welcome</h1>
   <div class="list-group">
-    <a href="#" class="list-group-item list-group-item-action" data-i18n="manageScripts">Manage Scripts</a>
-    <a href="/index.html" class="list-group-item list-group-item-action" data-i18n="logout">Logout</a>
+    <a href="/scripts.html" class="list-group-item list-group-item-action" data-i18n="manageScripts">Manage Scripts</a>
+    <a href="/myscripts.html" class="list-group-item list-group-item-action" data-i18n="myScripts">My Scripts</a>
+    <a href="#" id="logoutLink" class="list-group-item list-group-item-action" data-i18n="logout">Logout</a>
   </div>
   <script src="main.js"></script>
+  <script>
+    document.getElementById('logoutLink').addEventListener('click', async (e) => {
+      e.preventDefault();
+      await fetch('/api/auth/logout', { method: 'POST' });
+      window.location.href = '/index.html';
+    });
+    checkSession(true).then(user => {
+      if (user) {
+        document.querySelector('[data-i18n="welcome"]').textContent += ' ' + user.name;
+      }
+    });
+  </script>
 </body>
 </html>

--- a/public/index.html
+++ b/public/index.html
@@ -7,7 +7,7 @@
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css">
   <link rel="stylesheet" href="style.css">
 </head>
-<body class="container py-5">
+<body class="container py-5 fade-in">
   <header>
     <img src="logo.png" alt="logo">
     <div>
@@ -34,6 +34,11 @@
   <div id="message"></div>
   <script src="main.js"></script>
   <script>
+    checkSession(false).then(user => {
+      if (user) {
+        window.location.href = '/dashboard.html';
+      }
+    });
     document.getElementById('loginForm').addEventListener('submit', async (e) => {
       e.preventDefault();
       const res = await fetch('/api/auth/login', {
@@ -48,7 +53,6 @@
       const msg = document.getElementById('message');
       if (res.ok) {
         msg.textContent = data.message;
-        localStorage.setItem('user', JSON.stringify(data.user));
         window.location.href = '/dashboard.html';
       } else {
         msg.textContent = data.error;

--- a/public/main.js
+++ b/public/main.js
@@ -12,7 +12,19 @@ const translations = {
     dashboardTitle: 'Dashboard',
     welcome: 'Welcome',
     manageScripts: 'Manage Scripts',
-    logout: 'Logout'
+    logout: 'Logout',
+    createScript: 'Create Script',
+    script: 'Script',
+    frequency: 'Frequency',
+    daily: 'Daily',
+    weekly: 'Weekly',
+    monthly: 'Monthly',
+    hour: 'Hour',
+    emails: 'Emails',
+    create: 'Create',
+    myScripts: 'My Scripts',
+    update: 'Update',
+    noScripts: 'No scripts found'
   },
   es: {
     login: 'Iniciar sesión',
@@ -27,7 +39,19 @@ const translations = {
     dashboardTitle: 'Panel',
     welcome: 'Bienvenido',
     manageScripts: 'Gestionar Scripts',
-    logout: 'Cerrar sesión'
+    logout: 'Cerrar sesión',
+    createScript: 'Crear Script',
+    script: 'Script',
+    frequency: 'Frecuencia',
+    daily: 'Diario',
+    weekly: 'Semanal',
+    monthly: 'Mensual',
+    hour: 'Hora',
+    emails: 'Correos',
+    create: 'Crear',
+    myScripts: 'Mis Scripts',
+    update: 'Actualizar',
+    noScripts: 'No hay scripts'
   }
 };
 
@@ -68,6 +92,20 @@ function initDark() {
       setDark(!active);
       btn.textContent = !active ? '☀️' : '🌙';
     });
+  }
+}
+
+async function checkSession(redirect) {
+  try {
+    const res = await fetch('/api/auth/session');
+    const data = await res.json();
+    if (!data.user && redirect) {
+      window.location.href = '/index.html';
+    }
+    return data.user;
+  } catch (e) {
+    if (redirect) window.location.href = '/index.html';
+    return null;
   }
 }
 

--- a/public/myscripts.html
+++ b/public/myscripts.html
@@ -1,0 +1,88 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title data-i18n="myScripts">My Scripts</title>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css">
+  <link rel="stylesheet" href="style.css">
+</head>
+<body class="container py-5 fade-in">
+  <header>
+    <img src="logo.png" alt="logo">
+    <div>
+      <select id="langToggle" class="form-select d-inline w-auto me-2">
+        <option value="en">EN</option>
+        <option value="es">ES</option>
+      </select>
+      <button id="darkToggle" class="btn btn-sm btn-secondary">🌙</button>
+    </div>
+  </header>
+  <h1 data-i18n="myScripts" class="mb-4">My Scripts</h1>
+  <div id="scriptsList"></div>
+  <script src="main.js"></script>
+  <script>
+    async function loadScripts() {
+      const res = await fetch('/api/scripts');
+      const data = await res.json();
+      const list = document.getElementById('scriptsList');
+      list.innerHTML = '';
+      if (!data.length) {
+        const p = document.createElement('p');
+        p.setAttribute('data-i18n', 'noScripts');
+        p.textContent = translations[document.documentElement.lang].noScripts;
+        list.appendChild(p);
+        return;
+      }
+      data.forEach(sc => {
+        const form = document.createElement('form');
+        form.className = 'mb-4';
+        form.innerHTML = `
+          <div class="mb-2">
+            <label class="form-label" data-i18n="script">Script</label>
+            <textarea class="form-control" name="script" required>${sc.script}</textarea>
+          </div>
+          <div class="mb-2">
+            <label class="form-label" data-i18n="frequency">Frequency</label>
+            <select name="frequency" class="form-select">
+              <option value="daily" data-i18n="daily">Daily</option>
+              <option value="weekly" data-i18n="weekly">Weekly</option>
+              <option value="monthly" data-i18n="monthly">Monthly</option>
+            </select>
+          </div>
+          <div class="mb-2">
+            <label class="form-label" data-i18n="hour">Hour</label>
+            <input type="time" name="hour" class="form-control" step="300" value="${new Date(sc.next_execution).toISOString().substring(11,16)}" required>
+          </div>
+          <div class="mb-2">
+            <label class="form-label" data-i18n="emails">Emails</label>
+            <input type="text" name="emails" class="form-control" value="${sc.emails}" required>
+          </div>
+          <button type="submit" class="btn btn-primary" data-i18n="update">Update</button>
+        `;
+        form.querySelector('select[name="frequency"]').value = sc.period === 24 ? 'daily' : sc.period === 24*7 ? 'weekly' : 'monthly';
+        form.addEventListener('submit', async e => {
+          e.preventDefault();
+          const fd = new FormData(form);
+          const [h,m] = fd.get('hour').split(':');
+          await fetch('/api/scripts/' + sc.id, {
+            method: 'PUT',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({
+              script: fd.get('script'),
+              frequency: fd.get('frequency'),
+              hour: parseInt(h,10),
+              minute: parseInt(m,10),
+              emails: fd.get('emails')
+            })
+          });
+          loadScripts();
+        });
+        list.appendChild(form);
+      });
+      setLang(document.documentElement.lang);
+    }
+    checkSession(true).then(loadScripts);
+  </script>
+</body>
+</html>

--- a/public/register.html
+++ b/public/register.html
@@ -7,7 +7,7 @@
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css">
   <link rel="stylesheet" href="style.css">
 </head>
-<body class="container py-5">
+<body class="container py-5 fade-in">
   <header>
     <img src="logo.png" alt="logo">
     <div>
@@ -45,6 +45,11 @@
   <div id="message"></div>
   <script src="main.js"></script>
   <script>
+    checkSession(false).then(user => {
+      if (user) {
+        window.location.href = '/dashboard.html';
+      }
+    });
     document.getElementById('registerForm').addEventListener('submit', async (e) => {
       e.preventDefault();
       const res = await fetch('/api/auth/register', {
@@ -61,7 +66,7 @@
       const msg = document.getElementById('message');
       if (res.status === 201) {
         msg.textContent = data.message;
-        window.location.href = '/index.html';
+        window.location.href = '/dashboard.html';
       } else {
         msg.textContent = data.error;
       }

--- a/public/scripts.html
+++ b/public/scripts.html
@@ -1,0 +1,68 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title data-i18n="createScript">Create Script</title>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css">
+  <link rel="stylesheet" href="style.css">
+</head>
+<body class="container py-5 fade-in">
+  <header>
+    <img src="logo.png" alt="logo">
+    <div>
+      <select id="langToggle" class="form-select d-inline w-auto me-2">
+        <option value="en">EN</option>
+        <option value="es">ES</option>
+      </select>
+      <button id="darkToggle" class="btn btn-sm btn-secondary">🌙</button>
+    </div>
+  </header>
+  <h1 data-i18n="createScript" class="mb-4">Create Script</h1>
+  <form id="scriptForm">
+    <div class="mb-3">
+      <label for="script" class="form-label" data-i18n="script">Script</label>
+      <textarea id="script" class="form-control" required></textarea>
+    </div>
+    <div class="mb-3">
+      <label for="frequency" class="form-label" data-i18n="frequency">Frequency</label>
+      <select id="frequency" class="form-select">
+        <option value="daily" data-i18n="daily">Daily</option>
+        <option value="weekly" data-i18n="weekly">Weekly</option>
+        <option value="monthly" data-i18n="monthly">Monthly</option>
+      </select>
+    </div>
+    <div class="mb-3">
+      <label for="hour" class="form-label" data-i18n="hour">Hour</label>
+      <input type="time" id="hour" class="form-control" value="09:00" step="300" required>
+    </div>
+    <div class="mb-3">
+      <label for="emails" class="form-label" data-i18n="emails">Emails</label>
+      <input type="text" id="emails" class="form-control" placeholder="a@example.com" required>
+    </div>
+    <button type="submit" class="btn btn-primary" data-i18n="create">Create</button>
+  </form>
+  <div id="message"></div>
+  <script src="main.js"></script>
+  <script>
+    checkSession(true);
+    document.getElementById('scriptForm').addEventListener('submit', async (e) => {
+      e.preventDefault();
+      const [hourVal, minVal] = document.getElementById('hour').value.split(':');
+      const res = await fetch('/api/scripts', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          script: document.getElementById('script').value,
+          frequency: document.getElementById('frequency').value,
+          hour: parseInt(hourVal, 10),
+          minute: parseInt(minVal, 10),
+          emails: document.getElementById('emails').value
+        })
+      });
+      const data = await res.json();
+      document.getElementById('message').textContent = res.ok ? data.message : data.error;
+    });
+  </script>
+</body>
+</html>

--- a/public/style.css
+++ b/public/style.css
@@ -8,6 +8,7 @@ body {
   background-color: var(--bg-color);
   color: var(--text-color);
   font-family: Arial, sans-serif;
+  transition: background-color 0.3s ease, color 0.3s ease;
 }
 
 header {
@@ -33,4 +34,13 @@ header img {
 
 #message {
   margin-top: 1rem;
+}
+
+.fade-in {
+  animation: fadeIn 0.5s ease-in;
+}
+
+@keyframes fadeIn {
+  from { opacity: 0; transform: translateY(20px); }
+  to { opacity: 1; transform: translateY(0); }
 }

--- a/src/app.js
+++ b/src/app.js
@@ -3,9 +3,15 @@ const bodyParser = require('body-parser');
 const authRoutes = require('./routes/auth');
 const scriptRoutes = require('./routes/scripts');
 const scheduler = require('./scheduler');
+const session = require('express-session');
 
 const app = express();
 app.use(bodyParser.json());
+app.use(session({
+  secret: process.env.SESSION_SECRET || 'keyboard cat',
+  resave: false,
+  saveUninitialized: false,
+}));
 app.use(express.static('public'));
 
 app.use('/api/auth', authRoutes);

--- a/src/routes/scripts.js
+++ b/src/routes/scripts.js
@@ -2,9 +2,15 @@ const express = require('express');
 const pool = require('../db');
 const router = express.Router();
 
+router.use((req, res, next) => {
+  if (!req.session.user) {
+    return res.status(401).json({ error: 'Not authenticated' });
+  }
+  next();
+});
 router.get('/', async (req, res) => {
   try {
-    const { rows } = await pool.query('SELECT * FROM scripts');
+    const { rows } = await pool.query('SELECT * FROM scripts WHERE user_id = $1', [req.session.user.id]);
     res.json(rows);
   } catch (err) {
     console.error(err);
@@ -13,13 +19,49 @@ router.get('/', async (req, res) => {
 });
 
 router.post('/', async (req, res) => {
-  const { user_id, script, period, next_execution, emails } = req.body;
+  const { script, frequency, hour, minute, emails } = req.body;
+  const userId = req.session.user.id;
+  const periods = { daily: 24, weekly: 24 * 7, monthly: 24 * 30 };
+  const period = periods[frequency] || 24;
+  const now = new Date();
+  let next = new Date();
+  next.setHours(hour, minute || 0, 0, 0);
+  if (next <= now) {
+    if (frequency === 'daily') next.setDate(next.getDate() + 1);
+    else if (frequency === 'weekly') next.setDate(next.getDate() + 7);
+    else if (frequency === 'monthly') next.setMonth(next.getMonth() + 1);
+  }
   try {
     await pool.query(
       'INSERT INTO scripts(user_id, script, period, next_execution, emails) VALUES ($1, $2, $3, $4, $5)',
-      [user_id, script, period, next_execution, emails]
+      [userId, script, period, next, emails]
     );
     res.status(201).json({ message: 'Script created' });
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ error: 'DB error' });
+  }
+});
+
+router.put('/:id', async (req, res) => {
+  const { script, frequency, hour, minute, emails } = req.body;
+  const userId = req.session.user.id;
+  const periods = { daily: 24, weekly: 24 * 7, monthly: 24 * 30 };
+  const period = periods[frequency] || 24;
+  let next = new Date();
+  next.setHours(hour, minute || 0, 0, 0);
+  const now = new Date();
+  if (next <= now) {
+    if (frequency === 'daily') next.setDate(next.getDate() + 1);
+    else if (frequency === 'weekly') next.setDate(next.getDate() + 7);
+    else if (frequency === 'monthly') next.setMonth(next.getMonth() + 1);
+  }
+  try {
+    await pool.query(
+      'UPDATE scripts SET script=$1, period=$2, next_execution=$3, emails=$4 WHERE id=$5 AND user_id=$6',
+      [script, period, next, emails, req.params.id, userId]
+    );
+    res.json({ message: 'Script updated' });
   } catch (err) {
     console.error(err);
     res.status(500).json({ error: 'DB error' });

--- a/src/scheduler.js
+++ b/src/scheduler.js
@@ -18,9 +18,11 @@ const transporter = nodemailer.createTransport({
 });
 
 async function checkScripts() {
+  console.log('Scheduler tick', new Date().toISOString());
   try {
-    const { rows } = await pool.query('SELECT * FROM scripts WHERE next_execution <= NOW()');
+    const { rows } = await pool.query("SELECT * FROM scripts WHERE next_execution BETWEEN NOW() - INTERVAL '2 minutes' AND NOW() + INTERVAL '2 minutes'");
     for (const script of rows) {
+      console.log('Running script', script.id);
       const completion = await openai.chat.completions.create({
         model: 'gpt-3.5-turbo',
         messages: [{ role: 'user', content: script.script }],
@@ -43,5 +45,5 @@ async function checkScripts() {
 }
 
 module.exports.start = () => {
-  cron.schedule('* * * * *', checkScripts); // run every minute
+  cron.schedule('*/5 * * * *', checkScripts); // run every 5 minutes
 };


### PR DESCRIPTION
## Summary
- show a new "My Scripts" page for editing existing scripts
- translate new UI text for script list
- allow script updates via PUT API
- run scheduler every five minutes and only trigger scripts near their scheduled time
- document new scheduler behavior

## Testing
- `npm install`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68729c568f508330bd909d38012aa8d4