### PR TITLE
feat: enable web search with latest GPT API

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # MyAutoMails
 
 Simple web app for scheduling OpenAI-powered scripts and emailing the results.
+Uses OpenAI's GPT-4.1-mini model with built-in web search to keep answers current while remaining inexpensive.
 
 ## Setup
 1. Install dependencies with `npm install` (requires internet access).

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "express-session": "^1.18.1",
     "node-cron": "^3.0.3",
     "nodemailer": "^7.0.5",
-    "openai": "^4.30.0",
+    "openai": "^5.12.1",
     "pg": "^8.11.3"
   }
 }

--- a/src/routes/scripts.js
+++ b/src/routes/scripts.js
@@ -43,15 +43,13 @@ router.post('/test', async (req, res) => {
     if (parseInt(rows[0].count, 10) >= 3) {
       return res.status(429).json({ error: 'Daily test limit reached' });
     }
-    const completion = await openai.chat.completions.create({
-      model: 'gpt-3.5-turbo',
-      messages: [
-        { role: 'system', content: 'Responde de forma natural sin mencionar que eres una IA. Usa internet si es necesario.' },
-
-        { role: 'user', content: script }
-      ],
+    const completion = await openai.responses.create({
+      model: 'gpt-4.1-mini',
+      instructions: 'Responde de forma natural sin mencionar que eres una IA.',
+      input: script,
+      tools: [{ type: 'web-browsing' }],
     });
-    let answer = completion.choices[0].message.content;
+    let answer = completion.output_text;
     if (LIMITS[plan].output && answer.length > LIMITS[plan].output) {
       answer = answer.slice(0, LIMITS[plan].output) + '\nActualiza al plan pro para eliminar límites.';
     }

--- a/src/scheduler.js
+++ b/src/scheduler.js
@@ -30,15 +30,13 @@ async function checkScripts() {
       console.log('Running script', script.id, 'scheduled for', execDate.toISOString());
 
       const plan = script.plan || 'free';
-      const messages = [
-        { role: 'system', content: 'Responde de forma natural sin mencionar que eres una IA. Usa internet si es necesario.' },
-        { role: 'user', content: script.script },
-      ];
-      const completion = await openai.chat.completions.create({
-        model: 'gpt-4o-mini-realtime-preview',
-        messages,
+      const completion = await openai.responses.create({
+        model: 'gpt-4.1-mini',
+        instructions: 'Responde de forma natural sin mencionar que eres una IA.',
+        input: script.script,
+        tools: [{ type: 'web-browsing' }],
       });
-      let answer = completion.choices[0].message.content;
+      let answer = completion.output_text;
       if (plan === 'free' && answer.length > 500) {
         answer = answer.slice(0, 500) + '\nActualiza al plan pro para eliminar límites.';
       }


### PR DESCRIPTION
## Summary
- integrate new OpenAI Responses API with web-browsing support for scripts and scheduler
- upgrade to gpt-4.1-mini and update OpenAI dependency to v5
- document web-enabled GPT-4.1 mini usage

## Testing
- `npm install`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6895d4f0d1e483309108dc74501f7dc1