### PR TITLE
feat: add feedback animations and script schedule info

### DIFF
--- a/public/history.html
+++ b/public/history.html
@@ -58,11 +58,6 @@
         list.appendChild(div);
       });
     }
-    document.getElementById('logoutLink').addEventListener('click', async e => {
-      e.preventDefault();
-      await fetch('/api/auth/logout', { method: 'POST' });
-      window.location.href = '/index.html';
-    });
   </script>
 </body>
 </html>

--- a/public/index.html
+++ b/public/index.html
@@ -50,12 +50,10 @@
         })
       });
       const data = await res.json();
-      const msg = document.getElementById('message');
       if (res.ok) {
-        msg.textContent = data.message;
-        window.location.href = '/myscripts.html';
+        showFeedback(data.message, 'success', '/myscripts.html');
       } else {
-        msg.textContent = data.error;
+        showFeedback(data.error, 'danger');
       }
     });
   </script>

--- a/public/main.js
+++ b/public/main.js
@@ -91,6 +91,21 @@ const translations = {
   }
 };
 
+function showFeedback(message, type = 'success', redirect) {
+  let box = document.getElementById('message');
+  if (!box) {
+    box = document.createElement('div');
+    box.id = 'message';
+    document.body.appendChild(box);
+  }
+  box.textContent = message;
+  box.className = `alert alert-${type} position-fixed top-0 start-50 translate-middle-x mt-3 fade show`;
+  setTimeout(() => {
+    box.classList.remove('show');
+    if (redirect) setTimeout(() => (window.location.href = redirect), 500);
+  }, 2000);
+}
+
 function setLang(lang) {
   const dict = translations[lang];
   document.querySelectorAll('[data-i18n]').forEach(el => {
@@ -146,6 +161,22 @@ function initSidebar() {
   }
 }
 
+function initLogout() {
+  const link = document.getElementById('logoutLink');
+  if (link) {
+    link.addEventListener('click', async e => {
+      e.preventDefault();
+      const res = await fetch('/api/auth/logout', { method: 'POST' });
+      if (res.ok) {
+        const msg = document.documentElement.lang === 'es' ? 'Sesión cerrada' : 'Logged out';
+        showFeedback(msg, 'success', '/index.html');
+      } else {
+        showFeedback('Error', 'danger');
+      }
+    });
+  }
+}
+
 async function checkSession(redirect) {
   try {
     const res = await fetch('/api/auth/session');
@@ -164,4 +195,5 @@ document.addEventListener('DOMContentLoaded', () => {
   initLang();
   initDark();
   initSidebar();
+  initLogout();
 });

--- a/public/myscripts.html
+++ b/public/myscripts.html
@@ -54,8 +54,16 @@
       data.forEach(sc => {
         const details = document.createElement('details');
         details.className = 'mb-3';
+        const exec = new Date(sc.next_execution);
         const summary = document.createElement('summary');
-        summary.textContent = sc.script.slice(0,30) + (sc.script.length > 30 ? '...' : '');
+        const scriptSpan = document.createElement('span');
+        scriptSpan.className = 'script-text';
+        scriptSpan.textContent = sc.script;
+        const dateSpan = document.createElement('span');
+        dateSpan.className = 'next-exec';
+        dateSpan.textContent = exec.toLocaleString();
+        summary.appendChild(scriptSpan);
+        summary.appendChild(dateSpan);
         details.appendChild(summary);
         const form = document.createElement('form');
         form.className = 'mt-2';
@@ -102,7 +110,6 @@
           opt.textContent = String(m).padStart(2, '0');
           minSel.appendChild(opt);
         }
-        const exec = new Date(sc.next_execution);
         hourSel.value = exec.getHours();
         minSel.value = Math.floor(exec.getMinutes() / 5) * 5;
         const ta = form.querySelector('textarea[name="script"]');
@@ -115,7 +122,7 @@
         form.addEventListener('submit', async e => {
           e.preventDefault();
           const fd = new FormData(form);
-          await fetch('/api/scripts/' + sc.id, {
+          const res = await fetch('/api/scripts/' + sc.id, {
             method: 'PUT',
             headers: { 'Content-Type': 'application/json' },
             body: JSON.stringify({
@@ -127,6 +134,13 @@
               timezone: new Date().getTimezoneOffset()
             })
           });
+          if (res.ok) {
+            const msg = document.documentElement.lang === 'es' ? 'Actualizado' : 'Updated';
+            showFeedback(msg, 'success');
+          } else {
+            const data = await res.json();
+            showFeedback(data.error || 'Error', 'danger');
+          }
           loadScripts();
         });
         details.appendChild(form);
@@ -137,11 +151,6 @@
 
     checkSession(true).then(user => { currentUser = user; loadScripts(); });
 
-    document.getElementById('logoutLink').addEventListener('click', async e => {
-      e.preventDefault();
-      await fetch('/api/auth/logout', { method: 'POST' });
-      window.location.href = '/index.html';
-    });
   </script>
 </body>
 </html>

--- a/public/profile.html
+++ b/public/profile.html
@@ -60,27 +60,40 @@
     document.getElementById('nameForm').addEventListener('submit', async e => {
       e.preventDefault();
       const res = await fetch('/api/auth/user', { method: 'PUT', headers: {'Content-Type':'application/json'}, body: JSON.stringify({ name: document.getElementById('name').value }) });
-      if (res.ok) alert('Saved');
+      if (res.ok) {
+        const msg = document.documentElement.lang === 'es' ? 'Guardado' : 'Saved';
+        showFeedback(msg, 'success');
+      } else {
+        const data = await res.json();
+        showFeedback(data.error || 'Error', 'danger');
+      }
     });
 
     document.getElementById('passForm').addEventListener('submit', async e => {
       e.preventDefault();
       const res = await fetch('/api/auth/user', { method: 'PUT', headers: {'Content-Type':'application/json'}, body: JSON.stringify({ password: document.getElementById('newPass').value, oldPassword: document.getElementById('currentPass').value }) });
-      if (res.ok) alert('Saved');
+      if (res.ok) {
+        const msg = document.documentElement.lang === 'es' ? 'Guardado' : 'Saved';
+        showFeedback(msg, 'success');
+      } else {
+        const data = await res.json();
+        showFeedback(data.error || 'Error', 'danger');
+      }
     });
 
 
     document.getElementById('deleteBtn').addEventListener('click', async () => {
       if (!confirm('Delete account?')) return;
       const res = await fetch('/api/auth/user', { method: 'DELETE' });
-      if (res.ok) window.location.href = '/index.html';
+      if (res.ok) {
+        const msg = document.documentElement.lang === 'es' ? 'Cuenta eliminada' : 'Account deleted';
+        showFeedback(msg, 'success', '/index.html');
+      } else {
+        const data = await res.json();
+        showFeedback(data.error || 'Error', 'danger');
+      }
     });
 
-    document.getElementById('logoutLink').addEventListener('click', async e => {
-      e.preventDefault();
-      await fetch('/api/auth/logout', { method: 'POST' });
-      window.location.href = '/index.html';
-    });
   </script>
 </body>
 </html>

--- a/public/register.html
+++ b/public/register.html
@@ -105,12 +105,10 @@
         })
       });
       const data = await res.json();
-      const msg = document.getElementById('message');
       if (res.status === 201) {
-        msg.textContent = data.message;
-        window.location.href = '/myscripts.html';
+        showFeedback(data.message, 'success', '/myscripts.html');
       } else {
-        msg.textContent = data.error;
+        showFeedback(data.error, 'danger');
         formStep.classList.remove('d-none');
         planStep.classList.add('d-none');
       }

--- a/public/scripts.html
+++ b/public/scripts.html
@@ -122,12 +122,11 @@
         })
       });
       const data = await res.json();
-      document.getElementById('message').textContent = res.ok ? data.message : data.error;
-    });
-    document.getElementById('logoutLink').addEventListener('click', async (e) => {
-      e.preventDefault();
-      await fetch('/api/auth/logout', { method: 'POST' });
-      window.location.href = '/index.html';
+      if (res.ok) {
+        showFeedback(data.message, 'success', '/myscripts.html');
+      } else {
+        showFeedback(data.error, 'danger');
+      }
     });
   </script>
 </body>

--- a/public/style.css
+++ b/public/style.css
@@ -45,6 +45,7 @@ header img {
 
 #message {
   margin-top: 1rem;
+  z-index: 2000;
 }
 
 .fade-in {
@@ -68,6 +69,20 @@ details summary {
   cursor: pointer;
   color: var(--accent-color);
   margin-bottom: 0.5rem;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+details summary .script-text {
+  flex: 1 1 200px;
+  word-break: break-word;
+}
+
+details summary .next-exec {
+  flex: 0 0 auto;
+  white-space: nowrap;
+  color: var(--text-color);
 }
 
 /* sidebar */


### PR DESCRIPTION
## Summary
- add reusable `showFeedback` helper for animated success/error messages and redirect
- show full script with next execution date in My Scripts and ensure responsive layout
- add logout handler with feedback

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6895dcbd40e48330914d3d026d490411